### PR TITLE
練習問題の編集・更新処理を追加しました。

### DIFF
--- a/app/Http/Controllers/DrillsController.php
+++ b/app/Http/Controllers/DrillsController.php
@@ -43,4 +43,29 @@ class DrillsController extends Controller
 
         return redirect('/drills/new')->with('flash_message', __('Registered'));
     }
+
+    public function edit($id)
+    {
+
+        // IDが数値なのかをチェックする　※無駄なDBへの問い合わせをなくすため
+        if (!ctype_digit($id)) {
+            return redirect('drills/new')->with('flash_message', __('Invalid operation was performed.'));
+        }
+
+        $drill = Drill::find($id);
+        return view('drills.edit', ['drill' => $drill]);
+    }
+
+    public function update(Request $request, $id)
+    {
+        // IDが数値なのかをチェックする　※無駄なDBへの問い合わせをなくすため
+        if (!ctype_digit($id)) {
+            return redirect('drills/new')->with('flash_message', __('Invalid operation was performed.'));
+        }
+
+        $drill = Drill::find($id);
+        $drill->fill($request->all())->save();
+
+        return redirect('/drills')->with('flash_message', __('Update Complete.'));
+    }
 }

--- a/resources/lang/ja.json
+++ b/resources/lang/ja.json
@@ -1,10 +1,13 @@
 {
     "Drill Register":"練習登録",
+    "Drill Update":"練習更新",
+    "Drill List":"タイピング練習一覧",
     "Title":"タイトル",
     "Category":"カテゴリー",
     "Problem":"問題",
     "Register":"登録する",
     "Registered":"登録しました！",
-    "Drill List":"タイピング練習一覧",
-    "Go Practice":"練習する"
+    "Update Complete.":"更新が完了しました！",
+    "Go Practice":"練習する",
+    "Invalid operation was performed.":"不正な操作が行われました"
 }

--- a/resources/views/drills/edit.blade.php
+++ b/resources/views/drills/edit.blade.php
@@ -1,0 +1,74 @@
+@extends('layouts.app')
+
+@section('content')
+    <div class="container">
+        <div class="row justify-content-center">
+            <div class="col-md-8">
+                <div class="card">
+                    <div class="card-header">{{ __('Drill Update') }}</div>
+
+                    <div class="card-body">
+                        <form action="{{ route('drills.update',$drill->id) }}" method="post">
+                            @csrf
+
+                            <div class="form-group row">
+                                <label for="title" class="col-md-4 col-form-label text-md-right">
+                                    {{ __('Title') }}
+                                </label>
+                                <div class="col-md-6">
+                                    <input type="text" id="title" class="form-control @error('title')is-invalid @enderror" name="title" value="{{ old('title',$drill->title) }}" autocomplete="title" autofocus>
+                                    @error('title')
+                                        <span class="invalid-feedback" role="alert">
+                                            <strong>{{ $message }}</strong>
+                                        </span>
+                                    @enderror
+                                </div>
+                            </div>
+
+                            <div class="form-group row">
+                                <label for="category_name" class="col-md-4 col-form-label text-md-right">
+                                    {{ __('Category') }}
+                                </label>
+                                <div class="col-md-6">
+                                    <input type="text" id="category_name" class="form-control @error('category_name')is-invalid @enderror" name="category_name" value="{{ old('category_name',$drill->category_name) }}" autocomplete="category_name" autofocus>
+                                    @error('category_name')
+                                        <span class="invalid-feedback" role="alert">
+                                            <strong>{{ $message }}</strong>
+                                        </span>
+                                    @enderror
+                                </div>
+                            </div>
+
+                            {{-- 問題入力部分 --}}
+
+                            @for ($i = 1; $i <= 10; $i++)
+                                <div class="form-group row">
+                                    <label for="problem{{ $i-1 }}" class="col-md-4 col-form-label text-md-right">{{ __('Problem').$i }}</label>
+
+                                    <div class="col-md-6">
+                                        <input id="problem{{$i - 1}}" type="text" class="form-control @error('problem'.($i - 1)) is-invalid @enderror" name="problem{{$i - 1}}" value="{{ old('problem'.($i-1),$drill['problem'.($i - 1)]) }}" autocomplete="problem{{$i - 1}}" autofocus>
+
+                                        @error('problem'.($i - 1))
+                                            <span class="invalid-feedback" role="alert">
+                                                <strong>{{ $message }}</strong>
+                                            </span>
+                                        @enderror
+                                    </div>
+                                </div>
+                            @endfor
+
+                                <div class="form-group row mb-0">
+                                    <div class="col-md-6 offset-md-4">
+                                        <button type="submit" class="btn btn-primary">
+                                            {{ __('Register') }}
+                                        </button>
+                                    </div>
+                                </div>
+
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/drills/index.blade.php
+++ b/resources/views/drills/index.blade.php
@@ -10,7 +10,7 @@
                     <div class="card mb-3">
                         <div class="card-body">
                             <h3 class="card-title">{{ $drill->title }}</h3>
-                            <a href="#" class="btn btn-primary">
+                            <a href="{{ route('drills.edit',$drill->id) }}" class="btn btn-primary">
                                 {{ __('Go Practice') }}
                             </a>
                         </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -26,3 +26,5 @@ Route::get('/home', [HomeController::class, 'index'])->name('home');
 Route::get('/drills/new', [DrillsController::class, 'new'])->name('drills.new');
 Route::post('/drills', [DrillsController::class, 'create'])->name('drills.create');
 Route::get('/drills', [DrillsController::class, 'index'])->name('drills');
+Route::get('/drills/{id}/edit', [DrillsController::class, 'edit'])->name('drills.edit');
+Route::post('/drills/{id}/edit', [DrillsController::class, 'update'])->name('drills.update');


### PR DESCRIPTION
一覧から飛べるように設定し、idをもとに個別の問題に飛べるようになっています。
idは数値のみを許容し、文字がはいってくる場合はエラーを出しリダイレクトさせます。
※無駄なDB接続をなくすため

close #6 